### PR TITLE
Bunch of optimization and less code verbosity

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,8 +64,8 @@ git clone https://github.com/drwetter/testssl.sh.git
 git clone https://github.com/lunarca/SimpleEmailSpoofer 
 git clone https://github.com/arthepsy/ssh-audit 
 echo -e "$OKORANGE + -- --=[Setting up environment...$RESET"
-cd $PLUGINS_DIR/BruteX/
-bash install.sh
+cd $PLUGINS_DIR/Findsploit/ && sh install.sh
+cd $PLUGINS_DIR/BruteX/ && sh install.sh
 cd $INSTALL_DIR 
 mkdir $LOOT_DIR 2> /dev/null
 mkdir $LOOT_DIR/screenshots/ -p 2> /dev/null

--- a/sniper
+++ b/sniper
@@ -35,6 +35,7 @@
 TARGET="$1"
 MODE="$2"
 OPT1="$3"
+DISABLE_POSTGRESQL="true" # disabling postgresql startup, assuming it's running already
 INSTALL_DIR="/usr/share/sniper"
 LOOT_DIR="/usr/share/sniper/loot"
 PLUGINS_DIR="/usr/share/sniper/plugins"
@@ -94,7 +95,7 @@ function loot {
 	rm -f $LOOT_DIR/.fuse_* 2> /dev/null
 	echo -e "$OKORANGE + -- --=[Starting Metasploit service...$RESET"
 	/etc/init.d/metasploit start 2> /dev/null
-	/etc/init.d/postgresql start 2> /dev/null
+	if [ -z $DISABLE_POSTGRESQL ]; then /etc/init.d/postgresql start 2> /dev/null
 	echo -e "$OKORANGE + -- --=[Importing NMap XML files into Metasploit...$RESET"
 	msfconsole -x "workspace -a $WORKSPACE; workspace $WORKSPACE; db_import $LOOT_DIR/nmap/nmap*.xml; hosts; services; exit;"
 	echo -e "$OKORANGE + -- --=[Copying loot to workspace: $WORKSPACE...$RESET"
@@ -666,7 +667,7 @@ else
 	nmap -sU -T5 -p U:$OPT1 --open $TARGET
 fi
 
-service postgresql start
+if [ -z $DISABLE_POSTGRESQL ]; then service postgresql start
 
 echo ""
 echo -e "$OKGREEN + -- ----------------------------=[Running Intrusive Scans]=----------------- -- +$RESET"

--- a/sniper
+++ b/sniper
@@ -107,22 +107,8 @@ function loot {
 	cp -Rf $LOOT_DIR/imports/ $LOOT_DIR/workspace/$WORKSPACE/ 2> /dev/null
 	cp -Rf $LOOT_DIR/notes/ $LOOT_DIR/workspace/$WORKSPACE/ 2> /dev/null
 	cp -Rf $LOOT_DIR/web/ $LOOT_DIR/workspace/$WORKSPACE/ 2> /dev/null
-	rm -Rf $LOOT_DIR/screenshots/ 2> /dev/null
-	rm -Rf $LOOT_DIR/nmap/ 2> /dev/null
-	rm -Rf $LOOT_DIR/domains/ 2> /dev/null
-	rm -Rf $LOOT_DIR/output/ 2> /dev/null
-	rm -Rf $LOOT_DIR/reports/ 2> /dev/null
-	rm -Rf $LOOT_DIR/imports/ 2> /dev/null
-	rm -Rf $LOOT_DIR/notes/ 2> /dev/null
-	rm -Rf $LOOT_DIR/web/ 2> /dev/null
-	mkdir $LOOT_DIR/screenshots/ -p 2> /dev/null
-	mkdir $LOOT_DIR/nmap -p 2> /dev/null
-	mkdir $LOOT_DIR/domains -p 2> /dev/null
-	mkdir $LOOT_DIR/output -p 2> /dev/null
-	mkdir $LOOT_DIR/reports -p 2> /dev/null
-	mkdir $LOOT_DIR/imports -p 2> /dev/null
-	mkdir $LOOT_DIR/notes -p 2> /dev/null
-	mkdir $LOOT_DIR/web -p 2> /dev/null
+	rm -Rf $LOOT_DIR/{screenshots,nmap,domains,outputs,reports,imports,notes,web}/ 2> /dev/null
+	mkdir $LOOT_DIR/{screenshots,nmap,domains,outputs,reports,imports,notes,web}/ -p 2> /dev/null
 	echo -e "$OKORANGE + -- --=[Opening workspace directory...$RESET"
 	iceweasel 2> /dev/null &
 	sleep 2

--- a/sniper
+++ b/sniper
@@ -94,7 +94,7 @@ function loot {
 	rm -f $LOOT_DIR/.fuse_* 2> /dev/null
 	echo -e "$OKORANGE + -- --=[Starting Metasploit service...$RESET"
 	/etc/init.d/metasploit start 2> /dev/null
-#	/etc/init.d/postgresql start 2> /dev/null
+	/etc/init.d/postgresql start 2> /dev/null
 	echo -e "$OKORANGE + -- --=[Importing NMap XML files into Metasploit...$RESET"
 	msfconsole -x "workspace -a $WORKSPACE; workspace $WORKSPACE; db_import $LOOT_DIR/nmap/nmap*.xml; hosts; services; exit;"
 	echo -e "$OKORANGE + -- --=[Copying loot to workspace: $WORKSPACE...$RESET"
@@ -666,7 +666,7 @@ else
 	nmap -sU -T5 -p U:$OPT1 --open $TARGET
 fi
 
-# service postgresql start
+service postgresql start
 
 echo ""
 echo -e "$OKGREEN + -- ----------------------------=[Running Intrusive Scans]=----------------- -- +$RESET"

--- a/sniper
+++ b/sniper
@@ -666,7 +666,7 @@ else
 	nmap -sU -T5 -p U:$OPT1 --open $TARGET
 fi
 
-service postgresql start
+# service postgresql start
 
 echo ""
 echo -e "$OKGREEN + -- ----------------------------=[Running Intrusive Scans]=----------------- -- +$RESET"

--- a/sniper
+++ b/sniper
@@ -95,7 +95,7 @@ function loot {
 	rm -f $LOOT_DIR/.fuse_* 2> /dev/null
 	echo -e "$OKORANGE + -- --=[Starting Metasploit service...$RESET"
 	/etc/init.d/metasploit start 2> /dev/null
-	if [ -z $DISABLE_POSTGRESQL ]; then /etc/init.d/postgresql start 2> /dev/null
+	if [ -z $DISABLE_POSTGRESQL ]; then /etc/init.d/postgresql start 2> /dev/null; fi
 	echo -e "$OKORANGE + -- --=[Importing NMap XML files into Metasploit...$RESET"
 	msfconsole -x "workspace -a $WORKSPACE; workspace $WORKSPACE; db_import $LOOT_DIR/nmap/nmap*.xml; hosts; services; exit;"
 	echo -e "$OKORANGE + -- --=[Copying loot to workspace: $WORKSPACE...$RESET"
@@ -667,7 +667,7 @@ else
 	nmap -sU -T5 -p U:$OPT1 --open $TARGET
 fi
 
-if [ -z $DISABLE_POSTGRESQL ]; then service postgresql start
+if [ -z $DISABLE_POSTGRESQL ]; then service postgresql start; fi
 
 echo ""
 echo -e "$OKGREEN + -- ----------------------------=[Running Intrusive Scans]=----------------- -- +$RESET"


### PR DESCRIPTION
`DISABLE_POSTGRESQL` variable introduced. If set, `postgresql` does not start (assume it's already started either explicitly or through Docker container linking

Directory creation optimized through use of `{...}` syntax.