### PR TITLE
Resolve basename and absolute path for $TARGET list.

### DIFF
--- a/sniper
+++ b/sniper
@@ -662,10 +662,10 @@ fi
 
 if [ "$MODE" = "nuke" ]; then
 	if [ "$OPT1" = "report" ]; then
-		sniper $TARGET $MODE | tee $LOOT_DIR/sniper-$TARGET-$MODE-`date +%Y%m%d%H%M`.txt 2>&1
+                sniper $(realpath $TARGET) $MODE | tee $LOOT_DIR/sniper-$(basename $TARGET)-$MODE-`date +%Y%m%d%H%M`.txt 2>&1
 		exit
 	fi
-	for a in `cat $TARGET`; do
+        for a in `cat $(realpath $TARGET)`; do
 		echo -e "$OKRED "
 		echo -e "$OKRED                              ____"
 		echo -e "$OKRED                      __,-~~/~    \`---."


### PR DESCRIPTION
When running Sn1per in NUKE mode the `$TARGET` is used for report name and target list path. By using `$(basename $TARGET)` for the report name and `$(realpath $TARGET)` for a absolute path to the target list we limit r/w conflicts

Also fixes #64 I think. 