### PR TITLE
Fix dnscan path and go dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@ echo ""
 INSTALL_DIR=/usr/share/sniper
 LOOT_DIR=/usr/share/sniper/loot
 PLUGINS_DIR=/usr/share/sniper/plugins
+GO_DIR=~/go/bin
 
 echo -e "$OKGREEN + -- --=[This script will install sniper under $INSTALL_DIR. Are you sure you want to continue?$RESET"
 read answer
@@ -37,7 +38,7 @@ cp -Rf * $INSTALL_DIR 2> /dev/null
 cd $INSTALL_DIR
 
 echo -e "$OKORANGE + -- --=[Installing package dependencies...$RESET"
-apt-get install nfs-common eyewitness nodejs wafw00f xdg-utils metagoofil clusterd ruby rubygems python dos2unix zenmap sslyze arachni aha libxml2-utils rpcbind uniscan xprobe2 cutycapt host whois dirb dnsrecon curl nmap php php-curl hydra iceweasel wpscan sqlmap nbtscan enum4linux cisco-torch metasploit-framework theharvester dnsenum nikto smtp-user-enum whatweb sslscan amap jq
+apt-get install nfs-common eyewitness nodejs wafw00f xdg-utils metagoofil clusterd ruby rubygems python dos2unix zenmap sslyze arachni aha libxml2-utils rpcbind uniscan xprobe2 cutycapt host whois dirb dnsrecon curl nmap php php-curl hydra iceweasel wpscan sqlmap nbtscan enum4linux cisco-torch metasploit-framework theharvester dnsenum nikto smtp-user-enum whatweb sslscan amap jq golang
 apt-get install waffit 2> /dev/null
 pip install dnspython colorama tldextract urllib3 ipaddress requests
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
@@ -52,6 +53,7 @@ rm -Rf $PLUGINS_DIR 2> /dev/null
 mkdir $PLUGINS_DIR 2> /dev/null
 cd $PLUGINS_DIR
 mkdir -p $PLUGINS_DIR/nmap_scripts/ 2> /dev/null
+mkdir -p $GO_DIR
 
 echo -e "$OKORANGE + -- --=[Downloading extensions...$RESET"
 git clone https://github.com/1N3/Findsploit.git 
@@ -77,9 +79,9 @@ pip3 install -r $PLUGINS_DIR/dnscan/requirements.txt
 mv $INSTALL_DIR/bin/slurp.zip $PLUGINS_DIR
 unzip slurp.zip
 rm -f slurp.zip
-cd ~/go/bin/;go get github.com/Ice3man543/SubOver; mv SubOver /usr/local/bin/subover
-cd ~/go/bin;go get -u github.com/OWASP/Amass;mv amass /usr/local/bin/
-cd ~/go/bin;go get github.com/subfinder/subfinder; mv subfinder /usr/local/bin/subfinder
+cd ~/go/bin/;go get -u github.com/Ice3man543/SubOver; mv SubOver /usr/local/bin/subover
+cd ~/go/bin;go get -u github.com/OWASP/Amass/cmd/amass; mv amass /usr/local/bin/
+cd ~/go/bin;go get -u github.com/subfinder/subfinder; mv subfinder /usr/local/bin/subfinder
 cd $PLUGINS_DIR
 wget https://github.com/michenriksen/aquatone/blob/master/subdomains.lst -O /usr/share/sniper/plugins/Sublist3r/subdomains.lst
 wget https://raw.githubusercontent.com/1N3/IntruderPayloads/master/FuzzLists/dirbuster-quick.txt -O /usr/share/sniper/plugins/cansina/dirbuster-quick.txt

--- a/sniper
+++ b/sniper
@@ -1618,7 +1618,7 @@ if [ "$RECON" = "1" ]; then
     echo -e "$OKRED BRUTE FORCING DNS SUBDOMAINS VIA DNSCAN (THIS COULD TAKE A WHILE...) $RESET"
     echo -e "${OKGREEN}====================================================================================${RESET}"
     if [ "$DNSCAN" = "1" ]; then
-      python /pentest/recon/dnscan/dnscan.py -d $TARGET -w $DOMAINS_FULL -o $LOOT_DIR/domains/domains-dnscan-$TARGET.txt -i $LOOT_DIR/domains/domains-$TARGET-ips.txt
+      python3 $PLUGINS_DIR/dnscan/dnscan.py -d $TARGET -w $DOMAINS_FULL -o $LOOT_DIR/domains/domains-dnscan-$TARGET.txt -i $LOOT_DIR/domains/domains-$TARGET-ips.txt
       cat $LOOT_DIR/domains/domains-dnscan-$TARGET.txt | grep $TARGET | awk '{print $3}' | sort -u >> $LOOT_DIR/domains/domains-$TARGET.txt 2> /dev/null
       dos2unix $LOOT_DIR/domains/domains-$TARGET.txt 2>/dev/null
     fi


### PR DESCRIPTION
Fixes in **install.sh**
- Add **golang** to the list of installed packages
- Add **$GO_DIR** with value *~/go/bin*
- `mkdir $GO_DIR` for cd-ing into later when installing go packages, as it does not exist by default.
- Make all `go get` commands updates (-u)
- Fix `amass` `go get` url

Fixes in **sniper**
- Fix `dnscan` using */pentest* instead of **$PLUGINS_DIR**
- Fix `dnscan` called using different python versions.