### PR TITLE
LOOT_DIR variable moved to 190 line

### DIFF
--- a/sniper
+++ b/sniper
@@ -187,6 +187,7 @@ case $key in
     ;;
     -t|--target)
     TARGET="$2"
+    LOOT_DIR="$INSTALL_DIR/loot/$TARGET"
     shift # past argument
     shift # past argument
     ;;
@@ -288,7 +289,6 @@ case $key in
     ls -l $INSTALL_DIR/loot/workspace/
     echo ""
     echo "cd /usr/share/sniper/loot/workspace/"
-    LOOT_DIR="$INSTALL_DIR/loot/$TARGET"
     WORKSPACE_REPORT=$LOOT_DIR/sniper-report.html
     if [ -f $WORKSPACE_REPORT ]; then
       echo -e "$OKORANGE + -- --=[Loading Sn1per Professional...$RESET"

--- a/sniper
+++ b/sniper
@@ -5,7 +5,6 @@
 
 VER="7.0"
 INSTALL_DIR="/usr/share/sniper"
-LOOT_DIR="$INSTALL_DIR/loot/$TARGET"
 SNIPER_PRO=$INSTALL_DIR/pro.sh
 
 # INIT POSTGRESQL
@@ -289,6 +288,7 @@ case $key in
     ls -l $INSTALL_DIR/loot/workspace/
     echo ""
     echo "cd /usr/share/sniper/loot/workspace/"
+    LOOT_DIR="$INSTALL_DIR/loot/$TARGET"
     WORKSPACE_REPORT=$LOOT_DIR/sniper-report.html
     if [ -f $WORKSPACE_REPORT ]; then
       echo -e "$OKORANGE + -- --=[Loading Sn1per Professional...$RESET"


### PR DESCRIPTION
Since `$TARGET` variable is empty on the 8th line. The Value of `LOOT_DIR` is just  `/usr/share/sniper/loot`.
And due to this *loot* were not saving in the desired directory that is `/usr/share/sniper/loot/$TARGET` therefore I moved the LOOT_DIR variable to the necessary line.  
## Before  
```
root@kali:~/Desktop/Github/Sn1per# sniper -re -t testing.com
[*] Loaded configuration file from ~/.sniper.conf [OK]
[*] Saving loot to /usr/share/sniper/loot/ [OK]
```
## After  
```
root@kali:~/Desktop/Github/Sn1per# sniper -re -t testing.com
[*] Loaded configuration file from ~/.sniper.conf [OK]
[*] Saving loot to /usr/share/sniper/loot/testing.com [OK]
```