### PR TITLE
Updated installation of altdns

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -161,7 +161,6 @@ git clone https://github.com/hisxo/gitGraber.git
 git clone https://github.com/1N3/LinkFinder
 git clone https://github.com/christophetd/censys-subdomain-finder.git
 git clone https://github.com/rbsec/dnscan.git
-git clone https://github.com/infosec-au/altdns.git 
 git clone https://github.com/blechschmidt/massdns.git
 git clone https://github.com/ProjectAnte/dnsgen
 git clone https://github.com/scipag/vulscan
@@ -177,10 +176,7 @@ cd ..
 pip3 install -r $PLUGINS_DIR/gitGraber/requirements.txt
 pip3 install -r $PLUGINS_DIR/censys-subdomain-finder/requirements.txt
 pip3 install -r $PLUGINS_DIR/dnscan/requirements.txt 
-cd altdns
-pip3 install -r requirements.txt 
-python2 setup.py install 
-pip3 install py-altdns 2> /dev/null
+pip3 install py-altdns
 cd ..
 cd massdns
 make && make install

--- a/install.sh
+++ b/install.sh
@@ -177,7 +177,6 @@ pip3 install -r $PLUGINS_DIR/gitGraber/requirements.txt
 pip3 install -r $PLUGINS_DIR/censys-subdomain-finder/requirements.txt
 pip3 install -r $PLUGINS_DIR/dnscan/requirements.txt 
 pip3 install py-altdns
-cd ..
 cd massdns
 make && make install
 cd ..


### PR DESCRIPTION
Removed usage of `python2 ` and manual installation of `requirements.txt` since
there's a `pip3` package of `altdns` which takes care of everything. 

This way we don't have to install `python2` either (not that it gets installed) 

```bash
Package python-pip is not available but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However, the following packages replace it:
  python3-pip

Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package 'python3-pip' is not installed, so not removed
```

Environment: **WSL2**
```bash
PRETTY_NAME="Kali GNU/Linux Rolling"
NAME="Kali GNU/Linux"
ID=kali
VERSION="2021.2"
VERSION_ID="2021.2"
VERSION_CODENAME="kali-rolling"
ID_LIKE=debian
ANSI_COLOR="1;31"
HOME_URL="https://www.kali.org/"
SUPPORT_URL="https://forums.kali.org/"
BUG_REPORT_URL="https://bugs.kali.org/"
```