### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,48 +70,13 @@ fi
 
 echo -e "$OKBLUE[*]$RESET Installing package dependencies...$RESET"
 apt-get update
-apt-get install -y python3-paramiko
-apt-get install -y nfs-common
-apt-get install -y nodejs
-apt-get install -y wafw00f
-apt-get install -y xdg-utils
-apt-get install -y ruby
-apt-get install -y rubygems
-apt-get install -y python
-apt-get install -y dos2unix
-apt-get install -y aha
-apt-get install -y libxml2-utils
-apt-get install -y rpcbind
-apt-get install -y cutycapt
-apt-get install -y host
-apt-get install -y whois
-apt-get install -y dnsrecon
-apt-get install -y curl
-apt-get install -y nmap
-apt-get install -y php7.4
-apt-get install -y php7.4-curl
-apt-get install -y hydra
-apt-get install -y sqlmap
-apt-get install -y nbtscan
-apt-get install -y nikto
-apt-get install -y whatweb
-apt-get install -y sslscan
-apt-get install -y jq
-apt-get install -y golang
-apt-get install -y adb
-apt-get install -y xsltproc
-apt-get install -y ldapscripts
-apt-get install -y libssl-dev 2> /dev/null
-apt-get install -y python-pip 2> /dev/null
-apt-get remove -y python3-pip
-apt-get install -y python3-pip
-apt-get install -y xmlstarlet
-apt-get install -y net-tools
-apt-get install -y p7zip-full
-apt-get install -y jsbeautifier
-apt-get install -y theharvester 2> /dev/null
-apt-get install -y phantomjs 2> /dev/null
-apt-get install -y chromium 2> /dev/null
+for pkg in adb aha chromium curl cutycapt dnsrecon dos2unix golang host hydra jq jsbeautifier ldapscripts libssl-dev libxml2-utils nbtscan net-tools nfs-common nikto nmap nodejs p7zip-full phantomjs php7.4 php7.4-curl python python-pip python3-paramiko python3-pip rpcbind ruby rubygems sqlmap sslscan theharvester wafw00f whatweb whois xdg-utils xmlstarlet xsltproc; do
+  if [[ "$pkg" == "python3-pip" ]]; then
+    apt-get remove -y $pkg
+  elif ! hash $pkg 2>/dev/null; then
+    apt-get install -y $pkg 2>/dev/null
+  fi
+done
 
 echo -e "$OKBLUE[*]$RESET Installing Metasploit...$RESET"
 curl https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb > /tmp/msfinstall


### PR DESCRIPTION
I submitted a similar fix in the past but for reasons unknown it didnt make it in this release. I did fix an issue that was in the last proposed fixed and i tested it to make sure it worked
```
./test.sh
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  android-libadb android-libbase android-libboringssl android-libcrypto-utils android-libcutils android-liblog android-sdk-platform-tools-common
The following NEW packages will be installed:
  adb android-libadb android-libbase android-libboringssl android-libcrypto-utils android-libcutils android-liblog android-sdk-platform-tools-common
0 upgraded, 8 newly installed, 0 to remove and 221 not upgraded.
Need to get 1021 kB of archives.
After this operation, 3057 kB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 android-liblog amd64 1:10.0.0+r36-7 [44.4 kB]
Get:2 http://kali.download/kali kali-rolling/main amd64 android-libbase amd64 1:10.0.0+r36-7 [41.5 kB]
Get:3 http://kali.download/kali kali-rolling/main amd64 android-libboringssl amd64 10.0.0+r36-1 [612 kB]
Get:4 http://kali.download/kali kali-rolling/main amd64 android-libcrypto-utils amd64 1:10.0.0+r36-7 [12.3 kB]
Get:5 http://kali.download/kali kali-rolling/main amd64 android-libcutils amd64 1:10.0.0+r36-7 [33.3 kB]
Get:6 http://kali.download/kali kali-rolling/main amd64 android-libadb amd64 1:10.0.0+r36-7 [165 kB]
Get:7 http://kali.download/kali kali-rolling/main amd64 android-sdk-platform-tools-common all 28.0.2+3 [8020 B]
Get:8 http://kali.download/kali kali-rolling/main amd64 adb amd64 1:10.0.0+r36-7 [104 kB]
Fetched 1021 kB in 2s (632 kB/s)
Selecting previously unselected package android-liblog.
(Reading database ... 81152 files and directories currently installed.)
Preparing to unpack .../0-android-liblog_1%3a10.0.0+r36-7_amd64.deb ...
Unpacking android-liblog (1:10.0.0+r36-7) ...
Selecting previously unselected package android-libbase.
Preparing to unpack .../1-android-libbase_1%3a10.0.0+r36-7_amd64.deb ...
Unpacking android-libbase (1:10.0.0+r36-7) ...
Selecting previously unselected package android-libboringssl.
Preparing to unpack .../2-android-libboringssl_10.0.0+r36-1_amd64.deb ...
Unpacking android-libboringssl (10.0.0+r36-1) ...
Selecting previously unselected package android-libcrypto-utils.
Preparing to unpack .../3-android-libcrypto-utils_1%3a10.0.0+r36-7_amd64.deb ...
Unpacking android-libcrypto-utils (1:10.0.0+r36-7) ...
Selecting previously unselected package android-libcutils.
Preparing to unpack .../4-android-libcutils_1%3a10.0.0+r36-7_amd64.deb ...
Unpacking android-libcutils (1:10.0.0+r36-7) ...
Selecting previously unselected package android-libadb.
Preparing to unpack .../5-android-libadb_1%3a10.0.0+r36-7_amd64.deb ...
Unpacking android-libadb (1:10.0.0+r36-7) ...
Selecting previously unselected package android-sdk-platform-tools-common.
Preparing to unpack .../6-android-sdk-platform-tools-common_28.0.2+3_all.deb ...
Unpacking android-sdk-platform-tools-common (28.0.2+3) ...
Selecting previously unselected package adb.
Preparing to unpack .../7-adb_1%3a10.0.0+r36-7_amd64.deb ...
Unpacking adb (1:10.0.0+r36-7) ...
Setting up android-sdk-platform-tools-common (28.0.2+3) ...
Setting up android-liblog (1:10.0.0+r36-7) ...
Setting up android-libboringssl (10.0.0+r36-1) ...
Setting up android-libcrypto-utils (1:10.0.0+r36-7) ...
Setting up android-libbase (1:10.0.0+r36-7) ...
Setting up android-libcutils (1:10.0.0+r36-7) ...
Setting up android-libadb (1:10.0.0+r36-7) ...
Setting up adb (1:10.0.0+r36-7) ...
Processing triggers for libc-bin (2.31-9) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  libcurl4
The following NEW packages will be installed:
  curl
The following packages will be upgraded:
  libcurl4
1 upgraded, 1 newly installed, 0 to remove and 220 not upgraded.
Need to get 608 kB of archives.
After this operation, 438 kB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 libcurl4 amd64 7.74.0-1.3+b1 [341 kB]
Get:2 http://kali.download/kali kali-rolling/main amd64 curl amd64 7.74.0-1.3+b1 [267 kB]
Fetched 608 kB in 1s (719 kB/s)
(Reading database ... 81213 files and directories currently installed.)
Preparing to unpack .../libcurl4_7.74.0-1.3+b1_amd64.deb ...
Unpacking libcurl4:amd64 (7.74.0-1.3+b1) over (7.74.0-1) ...
Selecting previously unselected package curl.
Preparing to unpack .../curl_7.74.0-1.3+b1_amd64.deb ...
Unpacking curl (7.74.0-1.3+b1) ...
Setting up libcurl4:amd64 (7.74.0-1.3+b1) ...
Setting up curl (7.74.0-1.3+b1) ...
Processing triggers for libc-bin (2.31-9) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  avahi-daemon geoclue-2.0 gstreamer1.0-plugins-base iio-sensor-proxy iso-codes libavahi-core7 libavahi-glib1 libcdparanoia0 libdaemon0 libgstreamer-plugins-base1.0-0 libhyphen0 libjim0.79
  libmbim-glib4 libmbim-proxy libmm-glib0 libnl-3-200 libnl-genl-3-200 libnl-route-3-200 libnss-mdns liborc-0.4-0 libqmi-glib5 libqmi-proxy libqt5positioning5 libqt5qml5 libqt5qmlmodels5 libqt5quick5
  libqt5sensors5 libqt5webchannel5 libqt5webkit5 libvisual-0.4-0 libwoff1 modemmanager usb-modeswitch usb-modeswitch-data wpasupplicant
Suggested packages:
  avahi-autoipd xvfb gvfs isoquery libvisual-0.4-plugins avahi-autoipd | zeroconf qt5-qmltooling-plugins comgt wvdial wpagui libengine-pkcs11-openssl
The following NEW packages will be installed:
  avahi-daemon cutycapt geoclue-2.0 gstreamer1.0-plugins-base iio-sensor-proxy iso-codes libavahi-core7 libavahi-glib1 libcdparanoia0 libdaemon0 libgstreamer-plugins-base1.0-0 libhyphen0 libjim0.79
  libmbim-glib4 libmbim-proxy libmm-glib0 libnl-3-200 libnl-genl-3-200 libnl-route-3-200 libnss-mdns liborc-0.4-0 libqmi-glib5 libqmi-proxy libqt5positioning5 libqt5qml5 libqt5qmlmodels5 libqt5quick5
  libqt5sensors5 libqt5webchannel5 libqt5webkit5 libvisual-0.4-0 libwoff1 modemmanager usb-modeswitch usb-modeswitch-data wpasupplicant
0 upgraded, 36 newly installed, 0 to remove and 220 not upgraded.
Need to get 28.5 MB of archives.
After this operation, 108 MB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 libavahi-core7 amd64 0.8-5 [121 kB]
Get:2 http://kali.download/kali kali-rolling/main amd64 libdaemon0 amd64 0.14-7.1 [15.0 kB]
Get:3 http://kali.download/kali kali-rolling/main amd64 avahi-daemon amd64 0.8-5 [100 kB]
Get:4 http://kali.download/kali kali-rolling/main amd64 liborc-0.4-0 amd64 1:0.4.32-1 [192 kB]
Get:5 http://kali.download/kali kali-rolling/main amd64 iso-codes all 4.6.0-1 [2824 kB]
Get:6 http://kali.download/kali kali-rolling/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.18.4-2 [2154 kB]
Get:7 http://kali.download/kali kali-rolling/main amd64 libhyphen0 amd64 2.8.8-7 [32.5 kB]
Get:8 http://kali.download/kali kali-rolling/main amd64 libqt5positioning5 amd64 5.15.2+dfsg-2 [206 kB]
Get:9 http://kali.download/kali kali-rolling/main amd64 libqt5qml5 amd64 5.15.2+dfsg-6 [1317 kB]
Get:10 http://kali.download/kali kali-rolling/main amd64 libqt5qmlmodels5 amd64 5.15.2+dfsg-6 [193 kB]
Get:11 http://kali.download/kali kali-rolling/main amd64 libqt5quick5 amd64 5.15.2+dfsg-6 [1559 kB]
Get:12 http://kali.download/kali kali-rolling/main amd64 libqt5sensors5 amd64 5.15.2-2 [112 kB]
Get:13 http://kali.download/kali kali-rolling/main amd64 libqt5webchannel5 amd64 5.15.2-2 [58.0 kB]
Get:14 http://kali.download/kali kali-rolling/main amd64 libwoff1 amd64 1.0.2-1+b1 [42.4 kB]
Get:15 http://kali.download/kali kali-rolling/main amd64 libqt5webkit5 amd64 5.212.0~alpha4-11 [11.7 MB]
Get:16 http://kali.download/kali kali-rolling/main amd64 cutycapt amd64 0.0~svn10-0.1+b2 [18.5 kB]
Get:17 http://kali.download/kali kali-rolling/main amd64 libavahi-glib1 amd64 0.8-5 [44.1 kB]
Get:18 http://kali.download/kali kali-rolling/main amd64 libmm-glib0 amd64 1.14.12-0.1 [1104 kB]
Get:19 http://kali.download/kali kali-rolling/main amd64 geoclue-2.0 amd64 2.5.7-3 [108 kB]
Get:20 http://kali.download/kali kali-rolling/main amd64 libcdparanoia0 amd64 3.10.2+debian-13.1 [48.6 kB]
Get:21 http://kali.download/kali kali-rolling/main amd64 libvisual-0.4-0 amd64 0.4.0-17 [134 kB]
Get:22 http://kali.download/kali kali-rolling/main amd64 gstreamer1.0-plugins-base amd64 1.18.4-2 [1984 kB]
Get:23 http://kali.download/kali kali-rolling/main amd64 iio-sensor-proxy amd64 3.0-2 [39.6 kB]
Get:24 http://kali.download/kali kali-rolling/main amd64 libjim0.79 amd64 0.79+dfsg0-2 [120 kB]
Get:25 http://kali.download/kali kali-rolling/main amd64 libmbim-glib4 amd64 1.24.6-0.1 [187 kB]
Get:26 http://kali.download/kali kali-rolling/main amd64 libmbim-proxy amd64 1.24.6-0.1 [89.9 kB]
Get:27 http://kali.download/kali kali-rolling/main amd64 libnl-3-200 amd64 3.4.0-1+b1 [63.6 kB]
Get:28 http://kali.download/kali kali-rolling/main amd64 libnl-genl-3-200 amd64 3.4.0-1+b1 [21.2 kB]
Get:29 http://kali.download/kali kali-rolling/main amd64 libnl-route-3-200 amd64 3.4.0-1+b1 [161 kB]
Get:30 http://kali.download/kali kali-rolling/main amd64 libnss-mdns amd64 0.14.1-2 [26.9 kB]
Get:31 http://kali.download/kali kali-rolling/main amd64 libqmi-glib5 amd64 1.26.10-0.1 [583 kB]
Get:32 http://kali.download/kali kali-rolling/main amd64 libqmi-proxy amd64 1.26.10-0.1 [10.6 kB]
Get:33 http://kali.download/kali kali-rolling/main amd64 modemmanager amd64 1.14.12-0.1 [1719 kB]
Get:34 http://kali.download/kali kali-rolling/main amd64 usb-modeswitch-data all 20191128-3 [47.9 kB]
Get:35 http://kali.download/kali kali-rolling/main amd64 usb-modeswitch amd64 2.6.1-1 [59.2 kB]
Get:36 http://kali.download/kali kali-rolling/main amd64 wpasupplicant amd64 2:2.9.0-21 [1284 kB]
Fetched 28.5 MB in 11s (2688 kB/s)
Selecting previously unselected package libavahi-core7:amd64.
(Reading database ... 81223 files and directories currently installed.)
Preparing to unpack .../00-libavahi-core7_0.8-5_amd64.deb ...
Unpacking libavahi-core7:amd64 (0.8-5) ...
Selecting previously unselected package libdaemon0:amd64.
Preparing to unpack .../01-libdaemon0_0.14-7.1_amd64.deb ...
Unpacking libdaemon0:amd64 (0.14-7.1) ...
Selecting previously unselected package avahi-daemon.
Preparing to unpack .../02-avahi-daemon_0.8-5_amd64.deb ...
Unpacking avahi-daemon (0.8-5) ...
Selecting previously unselected package liborc-0.4-0:amd64.
Preparing to unpack .../03-liborc-0.4-0_1%3a0.4.32-1_amd64.deb ...
Unpacking liborc-0.4-0:amd64 (1:0.4.32-1) ...
Selecting previously unselected package iso-codes.
Preparing to unpack .../04-iso-codes_4.6.0-1_all.deb ...
Unpacking iso-codes (4.6.0-1) ...
Selecting previously unselected package libgstreamer-plugins-base1.0-0:amd64.
Preparing to unpack .../05-libgstreamer-plugins-base1.0-0_1.18.4-2_amd64.deb ...
Unpacking libgstreamer-plugins-base1.0-0:amd64 (1.18.4-2) ...
Selecting previously unselected package libhyphen0:amd64.
Preparing to unpack .../06-libhyphen0_2.8.8-7_amd64.deb ...
Unpacking libhyphen0:amd64 (2.8.8-7) ...
Selecting previously unselected package libqt5positioning5:amd64.
Preparing to unpack .../07-libqt5positioning5_5.15.2+dfsg-2_amd64.deb ...
Unpacking libqt5positioning5:amd64 (5.15.2+dfsg-2) ...
Selecting previously unselected package libqt5qml5:amd64.
Preparing to unpack .../08-libqt5qml5_5.15.2+dfsg-6_amd64.deb ...
Unpacking libqt5qml5:amd64 (5.15.2+dfsg-6) ...
Selecting previously unselected package libqt5qmlmodels5:amd64.
Preparing to unpack .../09-libqt5qmlmodels5_5.15.2+dfsg-6_amd64.deb ...
Unpacking libqt5qmlmodels5:amd64 (5.15.2+dfsg-6) ...
Selecting previously unselected package libqt5quick5:amd64.
Preparing to unpack .../10-libqt5quick5_5.15.2+dfsg-6_amd64.deb ...
Unpacking libqt5quick5:amd64 (5.15.2+dfsg-6) ...
Selecting previously unselected package libqt5sensors5:amd64.
Preparing to unpack .../11-libqt5sensors5_5.15.2-2_amd64.deb ...
Unpacking libqt5sensors5:amd64 (5.15.2-2) ...
Selecting previously unselected package libqt5webchannel5:amd64.
Preparing to unpack .../12-libqt5webchannel5_5.15.2-2_amd64.deb ...
Unpacking libqt5webchannel5:amd64 (5.15.2-2) ...
Selecting previously unselected package libwoff1:amd64.
Preparing to unpack .../13-libwoff1_1.0.2-1+b1_amd64.deb ...
Unpacking libwoff1:amd64 (1.0.2-1+b1) ...
Selecting previously unselected package libqt5webkit5:amd64.
Preparing to unpack .../14-libqt5webkit5_5.212.0~alpha4-11_amd64.deb ...
Unpacking libqt5webkit5:amd64 (5.212.0~alpha4-11) ...
Selecting previously unselected package cutycapt.
Preparing to unpack .../15-cutycapt_0.0~svn10-0.1+b2_amd64.deb ...
Unpacking cutycapt (0.0~svn10-0.1+b2) ...
Selecting previously unselected package libavahi-glib1:amd64.
Preparing to unpack .../16-libavahi-glib1_0.8-5_amd64.deb ...
Unpacking libavahi-glib1:amd64 (0.8-5) ...
Selecting previously unselected package libmm-glib0:amd64.
Preparing to unpack .../17-libmm-glib0_1.14.12-0.1_amd64.deb ...
Unpacking libmm-glib0:amd64 (1.14.12-0.1) ...
Selecting previously unselected package geoclue-2.0.
Preparing to unpack .../18-geoclue-2.0_2.5.7-3_amd64.deb ...
Unpacking geoclue-2.0 (2.5.7-3) ...
Selecting previously unselected package libcdparanoia0:amd64.
Preparing to unpack .../19-libcdparanoia0_3.10.2+debian-13.1_amd64.deb ...
Unpacking libcdparanoia0:amd64 (3.10.2+debian-13.1) ...
Selecting previously unselected package libvisual-0.4-0:amd64.
Preparing to unpack .../20-libvisual-0.4-0_0.4.0-17_amd64.deb ...
Unpacking libvisual-0.4-0:amd64 (0.4.0-17) ...
Selecting previously unselected package gstreamer1.0-plugins-base:amd64.
Preparing to unpack .../21-gstreamer1.0-plugins-base_1.18.4-2_amd64.deb ...
Unpacking gstreamer1.0-plugins-base:amd64 (1.18.4-2) ...
Selecting previously unselected package iio-sensor-proxy.
Preparing to unpack .../22-iio-sensor-proxy_3.0-2_amd64.deb ...
Unpacking iio-sensor-proxy (3.0-2) ...
Selecting previously unselected package libjim0.79:amd64.
Preparing to unpack .../23-libjim0.79_0.79+dfsg0-2_amd64.deb ...
Unpacking libjim0.79:amd64 (0.79+dfsg0-2) ...
Selecting previously unselected package libmbim-glib4:amd64.
Preparing to unpack .../24-libmbim-glib4_1.24.6-0.1_amd64.deb ...
Unpacking libmbim-glib4:amd64 (1.24.6-0.1) ...
Selecting previously unselected package libmbim-proxy.
Preparing to unpack .../25-libmbim-proxy_1.24.6-0.1_amd64.deb ...
Unpacking libmbim-proxy (1.24.6-0.1) ...
Selecting previously unselected package libnl-3-200:amd64.
Preparing to unpack .../26-libnl-3-200_3.4.0-1+b1_amd64.deb ...
Unpacking libnl-3-200:amd64 (3.4.0-1+b1) ...
Selecting previously unselected package libnl-genl-3-200:amd64.
Preparing to unpack .../27-libnl-genl-3-200_3.4.0-1+b1_amd64.deb ...
Unpacking libnl-genl-3-200:amd64 (3.4.0-1+b1) ...
Selecting previously unselected package libnl-route-3-200:amd64.
Preparing to unpack .../28-libnl-route-3-200_3.4.0-1+b1_amd64.deb ...
Unpacking libnl-route-3-200:amd64 (3.4.0-1+b1) ...
Selecting previously unselected package libnss-mdns:amd64.
Preparing to unpack .../29-libnss-mdns_0.14.1-2_amd64.deb ...
Unpacking libnss-mdns:amd64 (0.14.1-2) ...
Selecting previously unselected package libqmi-glib5:amd64.
Preparing to unpack .../30-libqmi-glib5_1.26.10-0.1_amd64.deb ...
Unpacking libqmi-glib5:amd64 (1.26.10-0.1) ...
Selecting previously unselected package libqmi-proxy.
Preparing to unpack .../31-libqmi-proxy_1.26.10-0.1_amd64.deb ...
Unpacking libqmi-proxy (1.26.10-0.1) ...
Selecting previously unselected package modemmanager.
Preparing to unpack .../32-modemmanager_1.14.12-0.1_amd64.deb ...
Unpacking modemmanager (1.14.12-0.1) ...
Selecting previously unselected package usb-modeswitch-data.
Preparing to unpack .../33-usb-modeswitch-data_20191128-3_all.deb ...
Unpacking usb-modeswitch-data (20191128-3) ...
Selecting previously unselected package usb-modeswitch.
Preparing to unpack .../34-usb-modeswitch_2.6.1-1_amd64.deb ...
Unpacking usb-modeswitch (2.6.1-1) ...
Selecting previously unselected package wpasupplicant.
Preparing to unpack .../35-wpasupplicant_2%3a2.9.0-21_amd64.deb ...
Unpacking wpasupplicant (2:2.9.0-21) ...
Setting up libcdparanoia0:amd64 (3.10.2+debian-13.1) ...
Setting up iio-sensor-proxy (3.0-2) ...
Setting up libjim0.79:amd64 (0.79+dfsg0-2) ...
Setting up libwoff1:amd64 (1.0.2-1+b1) ...
Setting up libhyphen0:amd64 (2.8.8-7) ...
Setting up libvisual-0.4-0:amd64 (0.4.0-17) ...
Setting up libqt5positioning5:amd64 (5.15.2+dfsg-2) ...
Setting up libqt5qml5:amd64 (5.15.2+dfsg-6) ...
Setting up usb-modeswitch-data (20191128-3) ...
Setting up liborc-0.4-0:amd64 (1:0.4.32-1) ...
Setting up libqt5webchannel5:amd64 (5.15.2-2) ...
Setting up libmm-glib0:amd64 (1.14.12-0.1) ...
Setting up libnl-3-200:amd64 (3.4.0-1+b1) ...
Setting up libavahi-glib1:amd64 (0.8-5) ...
Setting up usb-modeswitch (2.6.1-1) ...
Setting up libqt5sensors5:amd64 (5.15.2-2) ...
Setting up libdaemon0:amd64 (0.14-7.1) ...
Setting up libavahi-core7:amd64 (0.8-5) ...
Setting up iso-codes (4.6.0-1) ...
Setting up libmbim-glib4:amd64 (1.24.6-0.1) ...
Setting up libqt5qmlmodels5:amd64 (5.15.2+dfsg-6) ...
Setting up libgstreamer-plugins-base1.0-0:amd64 (1.18.4-2) ...
Setting up geoclue-2.0 (2.5.7-3) ...
Setting up libmbim-proxy (1.24.6-0.1) ...
Setting up libnl-route-3-200:amd64 (3.4.0-1+b1) ...
Setting up gstreamer1.0-plugins-base:amd64 (1.18.4-2) ...
Setting up avahi-daemon (0.8-5) ...
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of force-reload.
update-rc.d: As per Kali policy, avahi-daemon init script is left disabled.
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Setting up libnl-genl-3-200:amd64 (3.4.0-1+b1) ...
Setting up libnss-mdns:amd64 (0.14.1-2) ...
First installation detected...
Checking NSS setup...
Setting up libqt5quick5:amd64 (5.15.2+dfsg-6) ...
Setting up libqmi-glib5:amd64 (1.26.10-0.1) ...
Setting up libqt5webkit5:amd64 (5.212.0~alpha4-11) ...
Setting up cutycapt (0.0~svn10-0.1+b2) ...
Setting up wpasupplicant (2:2.9.0-21) ...
Setting up libqmi-proxy (1.26.10-0.1) ...
Setting up modemmanager (1.14.12-0.1) ...
Created symlink /etc/systemd/system/dbus-org.freedesktop.ModemManager1.service → /lib/systemd/system/ModemManager.service.
Created symlink /etc/systemd/system/multi-user.target.wants/ModemManager.service → /lib/systemd/system/ModemManager.service.
Processing triggers for hicolor-icon-theme (0.17-2) ...
Processing triggers for libc-bin (2.31-9) ...
Processing triggers for dbus (1.12.20-2) ...
Processing triggers for mailcap (3.68) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following NEW packages will be installed:
  dos2unix
0 upgraded, 1 newly installed, 0 to remove and 220 not upgraded.
Need to get 392 kB of archives.
After this operation, 1353 kB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 dos2unix amd64 7.4.1-1 [392 kB]
Fetched 392 kB in 0s (1185 kB/s)
Selecting previously unselected package dos2unix.
(Reading database ... 83035 files and directories currently installed.)
Preparing to unpack .../dos2unix_7.4.1-1_amd64.deb ...
Unpacking dos2unix (7.4.1-1) ...
Setting up dos2unix (7.4.1-1) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
golang is already the newest version (2:1.15~1).
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 220 not upgraded.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  firebird3.0-common firebird3.0-common-doc libavcodec58 libavformat58 libavutil56 libbson-1.0-0 libfbclient2 libfreerdp2-2 libidn11 libmariadb3 libmemcached11 libmongoc-1.0-0 libmongocrypt0 libssh-4
  libswresample3 libswscale5 libtommath1 libwinpr2-2 mariadb-common mysql-common
Suggested packages:
  hydra-gtk freerdp2-x11
The following NEW packages will be installed:
  firebird3.0-common firebird3.0-common-doc hydra libbson-1.0-0 libfbclient2 libfreerdp2-2 libidn11 libmariadb3 libmemcached11 libmongoc-1.0-0 libmongocrypt0 libssh-4 libswscale5 libtommath1
  libwinpr2-2 mariadb-common mysql-common
The following packages will be upgraded:
  libavcodec58 libavformat58 libavutil56 libswresample3
4 upgraded, 17 newly installed, 0 to remove and 216 not upgraded.
Need to get 9505 kB of archives.
After this operation, 10.2 MB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 firebird3.0-common-doc all 3.0.7.33374.ds4-2 [36.0 kB]
Get:2 http://kali.download/kali kali-rolling/main amd64 firebird3.0-common all 3.0.7.33374.ds4-2 [15.2 kB]
Get:3 http://kali.download/kali kali-rolling/main amd64 libbson-1.0-0 amd64 1.17.6-1 [73.6 kB]
Get:4 http://kali.download/kali kali-rolling/main amd64 libtommath1 amd64 1.2.0-6 [66.1 kB]
Get:5 http://kali.download/kali kali-rolling/main amd64 libfbclient2 amd64 3.0.7.33374.ds4-2 [530 kB]
Get:6 http://kali.download/kali kali-rolling/main amd64 libavformat58 amd64 7:4.3.2-0+deb11u2 [1046 kB]
Get:7 http://kali.download/kali kali-rolling/main amd64 libavcodec58 amd64 7:4.3.2-0+deb11u2 [4952 kB]
Get:8 http://kali.download/kali kali-rolling/main amd64 libswresample3 amd64 7:4.3.2-0+deb11u2 [101 kB]
Get:9 http://kali.download/kali kali-rolling/main amd64 libavutil56 amd64 7:4.3.2-0+deb11u2 [303 kB]
Get:10 http://kali.download/kali kali-rolling/main amd64 libswscale5 amd64 7:4.3.2-0+deb11u2 [202 kB]
Get:11 http://kali.download/kali kali-rolling/main amd64 libwinpr2-2 amd64 2.3.0+dfsg1-2 [344 kB]
Get:12 http://kali.download/kali kali-rolling/main amd64 libfreerdp2-2 amd64 2.3.0+dfsg1-2 [543 kB]
Get:13 http://kali.download/kali kali-rolling/main amd64 libidn11 amd64 1.33-3 [116 kB]
Get:14 http://kali.download/kali kali-rolling/main amd64 mysql-common all 5.8+1.0.7 [7464 B]
Get:15 http://kali.download/kali kali-rolling/main amd64 mariadb-common all 1:10.5.10-2 [36.0 kB]
Get:16 http://kali.download/kali kali-rolling/main amd64 libmariadb3 amd64 1:10.5.10-2 [174 kB]
Get:17 http://kali.download/kali kali-rolling/main amd64 libmemcached11 amd64 1.0.18-4.2 [94.5 kB]
Get:18 http://kali.download/kali kali-rolling/main amd64 libmongocrypt0 amd64 1.1.0-1 [124 kB]
Get:19 http://kali.download/kali kali-rolling/main amd64 libmongoc-1.0-0 amd64 1.17.6-1 [279 kB]
Get:20 http://kali.download/kali kali-rolling/main amd64 libssh-4 amd64 0.9.5-1 [186 kB]
Get:21 http://kali.download/kali kali-rolling/main amd64 hydra amd64 9.1-1 [276 kB]
Fetched 9505 kB in 26s (372 kB/s)
Selecting previously unselected package firebird3.0-common-doc.
(Reading database ... 83136 files and directories currently installed.)
Preparing to unpack .../00-firebird3.0-common-doc_3.0.7.33374.ds4-2_all.deb ...
Unpacking firebird3.0-common-doc (3.0.7.33374.ds4-2) ...
Selecting previously unselected package firebird3.0-common.
Preparing to unpack .../01-firebird3.0-common_3.0.7.33374.ds4-2_all.deb ...
Unpacking firebird3.0-common (3.0.7.33374.ds4-2) ...
Selecting previously unselected package libbson-1.0-0.
Preparing to unpack .../02-libbson-1.0-0_1.17.6-1_amd64.deb ...
Unpacking libbson-1.0-0 (1.17.6-1) ...
Selecting previously unselected package libtommath1:amd64.
Preparing to unpack .../03-libtommath1_1.2.0-6_amd64.deb ...
Unpacking libtommath1:amd64 (1.2.0-6) ...
Selecting previously unselected package libfbclient2:amd64.
Preparing to unpack .../04-libfbclient2_3.0.7.33374.ds4-2_amd64.deb ...
Unpacking libfbclient2:amd64 (3.0.7.33374.ds4-2) ...
Preparing to unpack .../05-libavformat58_7%3a4.3.2-0+deb11u2_amd64.deb ...
Unpacking libavformat58:amd64 (7:4.3.2-0+deb11u2) over (7:4.3.2-0+deb11u1) ...
Preparing to unpack .../06-libavcodec58_7%3a4.3.2-0+deb11u2_amd64.deb ...
Unpacking libavcodec58:amd64 (7:4.3.2-0+deb11u2) over (7:4.3.2-0+deb11u1) ...
Preparing to unpack .../07-libswresample3_7%3a4.3.2-0+deb11u2_amd64.deb ...
Unpacking libswresample3:amd64 (7:4.3.2-0+deb11u2) over (7:4.3.2-0+deb11u1) ...
Preparing to unpack .../08-libavutil56_7%3a4.3.2-0+deb11u2_amd64.deb ...
Unpacking libavutil56:amd64 (7:4.3.2-0+deb11u2) over (7:4.3.2-0+deb11u1) ...
Selecting previously unselected package libswscale5:amd64.
Preparing to unpack .../09-libswscale5_7%3a4.3.2-0+deb11u2_amd64.deb ...
Unpacking libswscale5:amd64 (7:4.3.2-0+deb11u2) ...
Selecting previously unselected package libwinpr2-2:amd64.
Preparing to unpack .../10-libwinpr2-2_2.3.0+dfsg1-2_amd64.deb ...
Unpacking libwinpr2-2:amd64 (2.3.0+dfsg1-2) ...
Selecting previously unselected package libfreerdp2-2:amd64.
Preparing to unpack .../11-libfreerdp2-2_2.3.0+dfsg1-2_amd64.deb ...
Unpacking libfreerdp2-2:amd64 (2.3.0+dfsg1-2) ...
Selecting previously unselected package libidn11:amd64.
Preparing to unpack .../12-libidn11_1.33-3_amd64.deb ...
Unpacking libidn11:amd64 (1.33-3) ...
Selecting previously unselected package mysql-common.
Preparing to unpack .../13-mysql-common_5.8+1.0.7_all.deb ...
Unpacking mysql-common (5.8+1.0.7) ...
Selecting previously unselected package mariadb-common.
Preparing to unpack .../14-mariadb-common_1%3a10.5.10-2_all.deb ...
Unpacking mariadb-common (1:10.5.10-2) ...
Selecting previously unselected package libmariadb3:amd64.
Preparing to unpack .../15-libmariadb3_1%3a10.5.10-2_amd64.deb ...
Unpacking libmariadb3:amd64 (1:10.5.10-2) ...
Selecting previously unselected package libmemcached11:amd64.
Preparing to unpack .../16-libmemcached11_1.0.18-4.2_amd64.deb ...
Unpacking libmemcached11:amd64 (1.0.18-4.2) ...
Selecting previously unselected package libmongocrypt0:amd64.
Preparing to unpack .../17-libmongocrypt0_1.1.0-1_amd64.deb ...
Unpacking libmongocrypt0:amd64 (1.1.0-1) ...
Selecting previously unselected package libmongoc-1.0-0.
Preparing to unpack .../18-libmongoc-1.0-0_1.17.6-1_amd64.deb ...
Unpacking libmongoc-1.0-0 (1.17.6-1) ...
Selecting previously unselected package libssh-4:amd64.
Preparing to unpack .../19-libssh-4_0.9.5-1_amd64.deb ...
Unpacking libssh-4:amd64 (0.9.5-1) ...
Selecting previously unselected package hydra.
Preparing to unpack .../20-hydra_9.1-1_amd64.deb ...
Unpacking hydra (9.1-1) ...
Setting up mysql-common (5.8+1.0.7) ...
update-alternatives: using /etc/mysql/my.cnf.fallback to provide /etc/mysql/my.cnf (my.cnf) in auto mode
Setting up libtommath1:amd64 (1.2.0-6) ...
Setting up libwinpr2-2:amd64 (2.3.0+dfsg1-2) ...
Setting up firebird3.0-common-doc (3.0.7.33374.ds4-2) ...
Setting up libavutil56:amd64 (7:4.3.2-0+deb11u2) ...
Setting up firebird3.0-common (3.0.7.33374.ds4-2) ...
Setting up mariadb-common (1:10.5.10-2) ...
update-alternatives: using /etc/mysql/mariadb.cnf to provide /etc/mysql/my.cnf (my.cnf) in auto mode
Setting up libidn11:amd64 (1.33-3) ...
Setting up libbson-1.0-0 (1.17.6-1) ...
Setting up libmariadb3:amd64 (1:10.5.10-2) ...
Setting up libssh-4:amd64 (0.9.5-1) ...
Setting up libmemcached11:amd64 (1.0.18-4.2) ...
Setting up libswscale5:amd64 (7:4.3.2-0+deb11u2) ...
Setting up libmongocrypt0:amd64 (1.1.0-1) ...
Setting up libswresample3:amd64 (7:4.3.2-0+deb11u2) ...
Setting up libfbclient2:amd64 (3.0.7.33374.ds4-2) ...
Setting up libmongoc-1.0-0 (1.17.6-1) ...
Setting up libavcodec58:amd64 (7:4.3.2-0+deb11u2) ...
Setting up libavformat58:amd64 (7:4.3.2-0+deb11u2) ...
Setting up libfreerdp2-2:amd64 (2.3.0+dfsg1-2) ...
Setting up hydra (9.1-1) ...
Processing triggers for libc-bin (2.31-9) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  python3-editorconfig python3-jsbeautifier
The following NEW packages will be installed:
  jsbeautifier python3-editorconfig python3-jsbeautifier
0 upgraded, 3 newly installed, 0 to remove and 216 not upgraded.
Need to get 79.6 kB of archives.
After this operation, 622 kB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 python3-editorconfig all 0.12.2-2.1 [14.1 kB]
Get:2 http://kali.download/kali kali-rolling/main amd64 python3-jsbeautifier all 1.13.0-1 [61.6 kB]
Get:3 http://kali.download/kali kali-rolling/main amd64 jsbeautifier all 1.13.0-1 [3772 B]
Fetched 79.6 kB in 1s (79.4 kB/s)
Selecting previously unselected package python3-editorconfig.
(Reading database ... 83280 files and directories currently installed.)
Preparing to unpack .../python3-editorconfig_0.12.2-2.1_all.deb ...
Unpacking python3-editorconfig (0.12.2-2.1) ...
Selecting previously unselected package python3-jsbeautifier.
Preparing to unpack .../python3-jsbeautifier_1.13.0-1_all.deb ...
Unpacking python3-jsbeautifier (1.13.0-1) ...
Selecting previously unselected package jsbeautifier.
Preparing to unpack .../jsbeautifier_1.13.0-1_all.deb ...
Unpacking jsbeautifier (1.13.0-1) ...
Setting up python3-editorconfig (0.12.2-2.1) ...
Setting up python3-jsbeautifier (1.13.0-1) ...
Setting up jsbeautifier (1.13.0-1) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  ldap-utils libldap-2.4-2 pwgen sharutils
Suggested packages:
  libsasl2-modules-gssapi-mit | libsasl2-modules-gssapi-heimdal nslcd sharutils-doc bsd-mailx | mailx
The following NEW packages will be installed:
  ldap-utils ldapscripts pwgen sharutils
The following packages will be upgraded:
  libldap-2.4-2
1 upgraded, 4 newly installed, 0 to remove and 215 not upgraded.
Need to get 775 kB of archives.
After this operation, 2407 kB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 libldap-2.4-2 amd64 2.4.57+dfsg-3 [232 kB]
Get:2 http://kali.download/kali kali-rolling/main amd64 ldap-utils amd64 2.4.57+dfsg-3 [206 kB]
Get:3 http://kali.download/kali kali-rolling/main amd64 ldapscripts all 2.0.8-2 [51.1 kB]
Get:4 http://kali.download/kali kali-rolling/main amd64 pwgen amd64 2.08-2 [19.6 kB]
Get:5 http://kali.download/kali kali-rolling/main amd64 sharutils amd64 1:4.15.2-5 [266 kB]
Fetched 775 kB in 2s (469 kB/s)
(Reading database ... 83351 files and directories currently installed.)
Preparing to unpack .../libldap-2.4-2_2.4.57+dfsg-3_amd64.deb ...
Unpacking libldap-2.4-2:amd64 (2.4.57+dfsg-3) over (2.4.57+dfsg-2) ...
Selecting previously unselected package ldap-utils.
Preparing to unpack .../ldap-utils_2.4.57+dfsg-3_amd64.deb ...
Unpacking ldap-utils (2.4.57+dfsg-3) ...
Selecting previously unselected package ldapscripts.
Preparing to unpack .../ldapscripts_2.0.8-2_all.deb ...
Unpacking ldapscripts (2.0.8-2) ...
Selecting previously unselected package pwgen.
Preparing to unpack .../pwgen_2.08-2_amd64.deb ...
Unpacking pwgen (2.08-2) ...
Selecting previously unselected package sharutils.
Preparing to unpack .../sharutils_1%3a4.15.2-5_amd64.deb ...
Unpacking sharutils (1:4.15.2-5) ...
Setting up libldap-2.4-2:amd64 (2.4.57+dfsg-3) ...
Setting up ldap-utils (2.4.57+dfsg-3) ...
Setting up sharutils (1:4.15.2-5) ...
Setting up pwgen (2.08-2) ...
Setting up ldapscripts (2.0.8-2) ...
Processing triggers for libc-bin (2.31-9) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  libssl1.1
Suggested packages:
  libssl-doc
The following packages will be upgraded:
  libssl-dev libssl1.1
2 upgraded, 0 newly installed, 0 to remove and 213 not upgraded.
Need to get 3363 kB of archives.
After this operation, 6144 B of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 libssl-dev amd64 1.1.1k-1 [1810 kB]
Get:2 http://kali.download/kali kali-rolling/main amd64 libssl1.1 amd64 1.1.1k-1 [1553 kB]
Fetched 3363 kB in 1s (5430 kB/s)
(Reading database ... 83489 files and directories currently installed.)
Preparing to unpack .../libssl-dev_1.1.1k-1_amd64.deb ...
Unpacking libssl-dev:amd64 (1.1.1k-1) over (1.1.1j-1) ...
Preparing to unpack .../libssl1.1_1.1.1k-1_amd64.deb ...
Unpacking libssl1.1:amd64 (1.1.1k-1) over (1.1.1j-1) ...
Setting up libssl1.1:amd64 (1.1.1k-1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Setting up libssl-dev:amd64 (1.1.1k-1) ...
Processing triggers for libc-bin (2.31-9) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following NEW packages will be installed:
  libxml2-utils
0 upgraded, 1 newly installed, 0 to remove and 213 not upgraded.
Need to get 109 kB of archives.
After this operation, 185 kB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 libxml2-utils amd64 2.9.10+dfsg-6.7 [109 kB]
Fetched 109 kB in 0s (255 kB/s)
Selecting previously unselected package libxml2-utils.
(Reading database ... 83489 files and directories currently installed.)
Preparing to unpack .../libxml2-utils_2.9.10+dfsg-6.7_amd64.deb ...
Unpacking libxml2-utils (2.9.10+dfsg-6.7) ...
Setting up libxml2-utils (2.9.10+dfsg-6.7) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following NEW packages will be installed:
  nbtscan
0 upgraded, 1 newly installed, 0 to remove and 213 not upgraded.
Need to get 23.2 kB of archives.
After this operation, 62.5 kB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 nbtscan amd64 1.6-3 [23.2 kB]
Fetched 23.2 kB in 0s (90.8 kB/s)
Selecting previously unselected package nbtscan.
(Reading database ... 83498 files and directories currently installed.)
Preparing to unpack .../nbtscan_1.6-3_amd64.deb ...
Unpacking nbtscan (1.6-3) ...
Setting up nbtscan (1.6-3) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following NEW packages will be installed:
  net-tools
0 upgraded, 1 newly installed, 0 to remove and 213 not upgraded.
Need to get 250 kB of archives.
After this operation, 1015 kB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 net-tools amd64 1.60+git20181103.0eebece-1 [250 kB]
Fetched 250 kB in 0s (1202 kB/s)
Selecting previously unselected package net-tools.
(Reading database ... 83506 files and directories currently installed.)
Preparing to unpack .../net-tools_1.60+git20181103.0eebece-1_amd64.deb ...
Unpacking net-tools (1.60+git20181103.0eebece-1) ...
Setting up net-tools (1.60+git20181103.0eebece-1) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  keyutils libnfsidmap2 rpcbind
Suggested packages:
  open-iscsi watchdog
The following NEW packages will be installed:
  keyutils libnfsidmap2 nfs-common rpcbind
0 upgraded, 4 newly installed, 0 to remove and 213 not upgraded.
Need to get 369 kB of archives.
After this operation, 1215 kB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 rpcbind amd64 1.2.5-9 [51.4 kB]
Get:2 http://kali.download/kali kali-rolling/main amd64 keyutils amd64 1.6.1-2 [52.8 kB]
Get:3 http://kali.download/kali kali-rolling/main amd64 libnfsidmap2 amd64 0.25-6 [32.6 kB]
Get:4 http://kali.download/kali kali-rolling/main amd64 nfs-common amd64 1:1.3.4-6 [232 kB]
Fetched 369 kB in 1s (610 kB/s)
Selecting previously unselected package rpcbind.
(Reading database ... 83563 files and directories currently installed.)
Preparing to unpack .../rpcbind_1.2.5-9_amd64.deb ...
Unpacking rpcbind (1.2.5-9) ...
Selecting previously unselected package keyutils.
Preparing to unpack .../keyutils_1.6.1-2_amd64.deb ...
Unpacking keyutils (1.6.1-2) ...
Selecting previously unselected package libnfsidmap2:amd64.
Preparing to unpack .../libnfsidmap2_0.25-6_amd64.deb ...
Unpacking libnfsidmap2:amd64 (0.25-6) ...
Selecting previously unselected package nfs-common.
Preparing to unpack .../nfs-common_1%3a1.3.4-6_amd64.deb ...
Unpacking nfs-common (1:1.3.4-6) ...
Setting up rpcbind (1.2.5-9) ...
update-rc.d: As per Kali policy, rpcbind init script is left disabled.
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Setting up keyutils (1.6.1-2) ...
Setting up libnfsidmap2:amd64 (0.25-6) ...
Setting up nfs-common (1:1.3.4-6) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/idmapd.conf with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Adding system user `statd' (UID 109) ...
Adding new user `statd' (UID 109) with group `nogroup' ...
Not creating home directory `/var/lib/nfs'.
Created symlink /etc/systemd/system/multi-user.target.wants/nfs-client.target → /lib/systemd/system/nfs-client.target.
Created symlink /etc/systemd/system/remote-fs.target.wants/nfs-client.target → /lib/systemd/system/nfs-client.target.
update-rc.d: As per Kali policy, nfs-common init script is left disabled.
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Processing triggers for libc-bin (2.31-9) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  libc-ares2 libjs-highlight.js libnode72 nodejs-doc
Suggested packages:
  npm
The following NEW packages will be installed:
  libc-ares2 libjs-highlight.js libnode72 nodejs nodejs-doc
0 upgraded, 5 newly installed, 0 to remove and 213 not upgraded.
Need to get 11.5 MB of archives.
After this operation, 50.5 MB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 libc-ares2 amd64 1.17.1-1 [101 kB]
Get:2 http://kali.download/kali kali-rolling/main amd64 libjs-highlight.js all 9.18.5+dfsg1-1 [397 kB]
Get:3 http://kali.download/kali kali-rolling/main amd64 libnode72 amd64 12.21.0~dfsg-5 [8329 kB]
Get:4 http://kali.download/kali kali-rolling/main amd64 nodejs amd64 12.21.0~dfsg-5 [146 kB]
Get:5 http://kali.download/kali kali-rolling/main amd64 nodejs-doc all 12.21.0~dfsg-5 [2538 kB]
Fetched 11.5 MB in 2s (5227 kB/s)
Selecting previously unselected package libc-ares2:amd64.
(Reading database ... 83684 files and directories currently installed.)
Preparing to unpack .../libc-ares2_1.17.1-1_amd64.deb ...
Unpacking libc-ares2:amd64 (1.17.1-1) ...
Selecting previously unselected package libjs-highlight.js.
Preparing to unpack .../libjs-highlight.js_9.18.5+dfsg1-1_all.deb ...
Unpacking libjs-highlight.js (9.18.5+dfsg1-1) ...
Selecting previously unselected package libnode72:amd64.
Preparing to unpack .../libnode72_12.21.0~dfsg-5_amd64.deb ...
Unpacking libnode72:amd64 (12.21.0~dfsg-5) ...
Selecting previously unselected package nodejs.
Preparing to unpack .../nodejs_12.21.0~dfsg-5_amd64.deb ...
Unpacking nodejs (12.21.0~dfsg-5) ...
Selecting previously unselected package nodejs-doc.
Preparing to unpack .../nodejs-doc_12.21.0~dfsg-5_all.deb ...
Unpacking nodejs-doc (12.21.0~dfsg-5) ...
Setting up libc-ares2:amd64 (1.17.1-1) ...
Setting up libnode72:amd64 (12.21.0~dfsg-5) ...
Setting up libjs-highlight.js (9.18.5+dfsg1-1) ...
Setting up nodejs (12.21.0~dfsg-5) ...
update-alternatives: using /usr/bin/nodejs to provide /usr/bin/js (js) in auto mode
Setting up nodejs-doc (12.21.0~dfsg-5) ...
Processing triggers for libc-bin (2.31-9) ...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
p7zip-full is already the newest version (16.02+dfsg-8).
p7zip-full set to manually installed.
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 213 not upgraded.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package phantomjs is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libassuan0 libfakeroot libksba8 libnpth0 make pinentry-curses python-pip-whl python3-distlib python3-filelock python3-importlib-metadata python3-ipython-genutils
  python3-jsonschema python3-jupyter-core python3-more-itertools python3-nbformat python3-plotly python3-pyrsistent python3-setuptools python3-traitlets python3-tz python3-virtualenv-clone
  python3-wheel python3-zipp
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php7.4 libaprutil1-dbd-sqlite3 libaprutil1-ldap php-common php7.4-cli php7.4-common php7.4-json php7.4-opcache php7.4-readline ssl-cert
Suggested packages:
  apache2-doc apache2-suexec-pristine | apache2-suexec-custom php-pear
The following NEW packages will be installed:
  apache2 apache2-bin apache2-data apache2-utils libapache2-mod-php7.4 libaprutil1-dbd-sqlite3 libaprutil1-ldap php-common php7.4 php7.4-cli php7.4-common php7.4-json php7.4-opcache php7.4-readline
  ssl-cert
0 upgraded, 15 newly installed, 0 to remove and 213 not upgraded.
Need to get 6237 kB of archives.
After this operation, 25.3 MB of additional disk space will be used.
Get:1 http://kali.download/kali kali-rolling/main amd64 libaprutil1-dbd-sqlite3 amd64 1.6.1-5 [18.8 kB]
Get:2 http://kali.download/kali kali-rolling/main amd64 libaprutil1-ldap amd64 1.6.1-5 [17.0 kB]
Get:3 http://kali.download/kali kali-rolling/main amd64 apache2-bin amd64 2.4.48-3.1 [1392 kB]
Get:4 http://kali.download/kali kali-rolling/main amd64 apache2-data all 2.4.48-3.1 [160 kB]
Get:5 http://kali.download/kali kali-rolling/main amd64 apache2-utils amd64 2.4.48-3.1 [252 kB]
Get:6 http://kali.download/kali kali-rolling/main amd64 apache2 amd64 2.4.48-3.1 [266 kB]
Get:7 http://kali.download/kali kali-rolling/main amd64 php-common all 2:76 [15.6 kB]
Get:8 http://kali.download/kali kali-rolling/main amd64 php7.4-common amd64 7.4.21-1+deb11u1 [1019 kB]
Get:9 http://kali.download/kali kali-rolling/main amd64 php7.4-json amd64 7.4.21-1+deb11u1 [19.3 kB]
Get:10 http://kali.download/kali kali-rolling/main amd64 php7.4-opcache amd64 7.4.21-1+deb11u1 [198 kB]
Get:11 http://kali.download/kali kali-rolling/main amd64 php7.4-readline amd64 7.4.21-1+deb11u1 [12.3 kB]
Get:12 http://kali.download/kali kali-rolling/main amd64 php7.4-cli amd64 7.4.21-1+deb11u1 [1426 kB]
Get:13 http://kali.download/kali kali-rolling/main amd64 libapache2-mod-php7.4 amd64 7.4.21-1+deb11u1 [1374 kB]
Get:14 http://kali.download/kali kali-rolling/main amd64 php7.4 all 7.4.21-1+deb11u1 [47.3 kB]
Get:15 http://kali.download/kali kali-rolling/main amd64 ssl-cert all 1.1.0+nmu1 [21.0 kB]
Fetched 6237 kB in 3s (2042 kB/s)
Selecting previously unselected package libaprutil1-dbd-sqlite3:amd64.
(Reading database ... 84055 files and directories currently installed.)
Preparing to unpack .../00-libaprutil1-dbd-sqlite3_1.6.1-5_amd64.deb ...
Unpacking libaprutil1-dbd-sqlite3:amd64 (1.6.1-5) ...
Selecting previously unselected package libaprutil1-ldap:amd64.
Preparing to unpack .../01-libaprutil1-ldap_1.6.1-5_amd64.deb ...
Unpacking libaprutil1-ldap:amd64 (1.6.1-5) ...
Selecting previously unselected package apache2-bin.
Preparing to unpack .../02-apache2-bin_2.4.48-3.1_amd64.deb ...
Unpacking apache2-bin (2.4.48-3.1) ...
Selecting previously unselected package apache2-data.
Preparing to unpack .../03-apache2-data_2.4.48-3.1_all.deb ...
Unpacking apache2-data (2.4.48-3.1) ...
Selecting previously unselected package apache2-utils.
Preparing to unpack .../04-apache2-utils_2.4.48-3.1_amd64.deb ...
Unpacking apache2-utils (2.4.48-3.1) ...
Selecting previously unselected package apache2.
Preparing to unpack .../05-apache2_2.4.48-3.1_amd64.deb ...
Unpacking apache2 (2.4.48-3.1) ...
Selecting previously unselected package php-common.
Preparing to unpack .../06-php-common_2%3a76_all.deb ...
Unpacking php-common (2:76) ...
Selecting previously unselected package php7.4-common.
Preparing to unpack .../07-php7.4-common_7.4.21-1+deb11u1_amd64.deb ...
Unpacking php7.4-common (7.4.21-1+deb11u1) ...
Selecting previously unselected package php7.4-json.
Preparing to unpack .../08-php7.4-json_7.4.21-1+deb11u1_amd64.deb ...
Unpacking php7.4-json (7.4.21-1+deb11u1) ...
Selecting previously unselected package php7.4-opcache.
Preparing to unpack .../09-php7.4-opcache_7.4.21-1+deb11u1_amd64.deb ...
Unpacking php7.4-opcache (7.4.21-1+deb11u1) ...
Selecting previously unselected package php7.4-readline.
Preparing to unpack .../10-php7.4-readline_7.4.21-1+deb11u1_amd64.deb ...
Unpacking php7.4-readline (7.4.21-1+deb11u1) ...
Selecting previously unselected package php7.4-cli.
Preparing to unpack .../11-php7.4-cli_7.4.21-1+deb11u1_amd64.deb ...
Unpacking php7.4-cli (7.4.21-1+deb11u1) ...
Selecting previously unselected package libapache2-mod-php7.4.
Preparing to unpack .../12-libapache2-mod-php7.4_7.4.21-1+deb11u1_amd64.deb ...
Unpacking libapache2-mod-php7.4 (7.4.21-1+deb11u1) ...
Selecting previously unselected package php7.4.
Preparing to unpack .../13-php7.4_7.4.21-1+deb11u1_all.deb ...
Unpacking php7.4 (7.4.21-1+deb11u1) ...
Selecting previously unselected package ssl-cert.
Preparing to unpack .../14-ssl-cert_1.1.0+nmu1_all.deb ...
Unpacking ssl-cert (1.1.0+nmu1) ...
Setting up php-common (2:76) ...
Created symlink /etc/systemd/system/timers.target.wants/phpsessionclean.timer → /lib/systemd/system/phpsessionclean.timer.
Setting up php7.4-common (7.4.21-1+deb11u1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/calendar.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/ctype.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/exif.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/fileinfo.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/ffi.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/ftp.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/gettext.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/iconv.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/pdo.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/phar.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/posix.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/shmop.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/sockets.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/sysvmsg.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/sysvsem.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/sysvshm.ini with new version
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/tokenizer.ini with new version
Setting up php7.4-readline (7.4.21-1+deb11u1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/readline.ini with new version
Setting up libaprutil1-ldap:amd64 (1.6.1-5) ...
Setting up libaprutil1-dbd-sqlite3:amd64 (1.6.1-5) ...
Setting up ssl-cert (1.1.0+nmu1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline
Setting up php7.4-opcache (7.4.21-1+deb11u1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/opcache.ini with new version
Setting up apache2-data (2.4.48-3.1) ...
Setting up apache2-utils (2.4.48-3.1) ...
Setting up php7.4-json (7.4.21-1+deb11u1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/mods-available/json.ini with new version
Setting up php7.4-cli (7.4.21-1+deb11u1) ...
update-alternatives: using /usr/bin/php7.4 to provide /usr/bin/php (php) in auto mode
update-alternatives: using /usr/bin/phar7.4 to provide /usr/bin/phar (phar) in auto mode
update-alternatives: using /usr/bin/phar.phar7.4 to provide /usr/bin/phar.phar (phar.phar) in auto mode
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76.)
debconf: falling back to frontend: Readline

Creating config file /etc/php/7.4/cli/php.ini with new versi…