### PR TITLE
Update go get to go install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -312,6 +312,11 @@ echo -e "$OKBLUE[*]$RESET Installing PureDNS...$RESET"
 go install github.com/d3mondev/puredns/v2@latest
 ln -s /root/go/bin/puredns /usr/bin/puredns 2> /dev/null
 
+# AMASS INSTALLER
+echo -e "$OKBLUE[*]$RESET Installing AMass...$RESET"
+go get github.com/OWASP/Amass/VS/...
+cd /root/go/bin/
+
 # SUBFINDER INSTALLER
 echo -e "$OKBLUE[*]$RESET Installing SubFinder...$RESET"
 go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest

--- a/install.sh
+++ b/install.sh
@@ -267,30 +267,34 @@ pip3 install -U webtech
 
 # INSTALL SUBJACK
 echo -e "$OKBLUE[*]$RESET Installing SubJack...$RESET"
-cd ~/go/bin/;go get github.com/haccer/subjack
+cd ~/go/bin/
+go install github.com/haccer/subjack@latest
 
 # INSTALL SUBOVER
 echo -e "$OKBLUE[*]$RESET Installing SubOver...$RESET"
-cd ~/go/bin/;go get -u github.com/Ice3man543/SubOver; mv SubOver /usr/local/bin/subover
+cd ~/go/bin/
+go install github.com/Ice3man543/SubOver@latest
+mv SubOver /usr/local/bin/subover
 
 # INSTALL FPROBE
 echo -e "$OKBLUE[*]$RESET Installing FProbe...$RESET"
-GO111MODULE=on go get -u github.com/theblackturtle/fprobe; ln -fs ~/go/bin/fprobe /usr/bin/fprobe
+go install github.com/theblackturtle/fprobe@latest
+ln -fs ~/go/bin/fprobe /usr/bin/fprobe
 
 # INSTALL ASNIP
 echo -e "$OKBLUE[*]$RESET Installing ASnip...$RESET"
-go get github.com/harleo/asnip
+go install github.com/harleo/asnip@latest
 ln -s ~/go/bin/asnip /usr/bin/asnip 2>/dev/null
 
 # GAU INSTALLER
 echo -e "$OKBLUE[*]$RESET Installing GAU...$RESET"
-GO111MODULE=on go get -u -v github.com/lc/gau
+go install github.com/lc/gau@latest
 rm -f /usr/bin/gau 2> /dev/null
 ln -s /root/go/bin/gau /usr/bin/gau 2> /dev/null
 
 # INSTALL HTTPX
 echo -e "$OKBLUE[*]$RESET Installing HTTPX...$RESET"
-GO111MODULE=auto go get -u -v github.com/projectdiscovery/httpx/cmd/httpx
+go install github.com/projectdiscovery/httpx/cmd/httpx@latest
 ln -s /root/go/bin/httpx /usr/bin/httpx 2> /dev/null
 
 # INSTALL FFUF

--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,6 @@ if [[ $UBUNTU_CHECK == "DISTRIB_ID=Ubuntu" ]]; then
 	ln -s /snap/bin/chromium /usr/bin/chromium 2> /dev/null
 	xhost + 2> /dev/null
 	mkdir -p /run/user/0 2> /dev/null
-	add-apt-repository ppa:longsleep/golang-backports
 	sudo apt update
 fi
 
@@ -98,7 +97,6 @@ apt-get install -y nikto
 apt-get install -y whatweb
 apt-get install -y sslscan
 apt-get install -y jq
-apt-get install -y golang
 apt-get install -y adb
 apt-get install -y xsltproc
 apt-get install -y ldapscripts

--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,6 @@ if [[ $UBUNTU_CHECK == "DISTRIB_ID=Ubuntu" ]]; then
 	mkdir -p /run/user/0 2> /dev/null
 	add-apt-repository ppa:longsleep/golang-backports
 	sudo apt update
-	apt install golang
 fi
 
 echo -e "$OKBLUE[*]$RESET Installing package dependencies...$RESET"

--- a/install.sh
+++ b/install.sh
@@ -295,33 +295,32 @@ ln -s /root/go/bin/httpx /usr/bin/httpx 2> /dev/null
 
 # INSTALL FFUF
 echo -e "$OKBLUE[*]$RESET Installing FFuF...$RESET"
-go get -u github.com/ffuf/ffuf
+go install github.com/ffuf/ffuf@latest
 ln -s /root/go/bin/ffuf /usr/bin/ffuf 2> /dev/null
 
 # GITHUB-ENDPOINTS INSTALLER
 echo -e "$OKBLUE[*]$RESET Installing Github-Endpoints...$RESET"
-go get -u github.com/gwen001/github-endpoints
+go install github.com/gwen001/github-endpoints@latest
 ln -s /root/go/bin/github-endpoints /usr/bin/github-endpoints 2> /dev/null
 
 # PUREDNS INSTALLER
 echo -e "$OKBLUE[*]$RESET Installing PureDNS...$RESET"
-GO111MODULE=on go get github.com/d3mondev/puredns/v2
+go install github.com/d3mondev/puredns/v2@latest
 ln -s /root/go/bin/puredns /usr/bin/puredns 2> /dev/null
 
 # AMASS INSTALLER
 echo -e "$OKBLUE[*]$RESET Installing AMass...$RESET"
-export GO111MODULE=on
-go get -v github.com/OWASP/Amass/cmd/amass
+go get github.com/OWASP/Amass/v3/...
 cd /root/go/bin/
 
 # SUBFINDER INSTALLER
 echo -e "$OKBLUE[*]$RESET Installing SubFinder...$RESET"
-GO111MODULE=on go get -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
+go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
 ln -s /root/go/bin/subfinder /usr/local/bin/subfinder 2> /dev/null
 
 # DIRDAR INSTALLER
 echo -e "$OKBLUE[*]$RESET Installing DirDar...$RESET"
-go get -u github.com/1N3/dirdar
+go install github.com/1N3/dirdar@latest
 ln -s /root/go/bin/dirdar /usr/local/bin/dirdar 2> /dev/null
 
 # VULNERS NMAP INSTALLER

--- a/installv1.sh
+++ b/installv1.sh
@@ -312,11 +312,6 @@ echo -e "$OKBLUE[*]$RESET Installing PureDNS...$RESET"
 go install github.com/d3mondev/puredns/v2@latest
 ln -s /root/go/bin/puredns /usr/bin/puredns 2> /dev/null
 
-# AMASS INSTALLER
-echo -e "$OKBLUE[*]$RESET Installing AMass...$RESET"
-go get github.com/OWASP/Amass/v3/...
-cd /root/go/bin/
-
 # SUBFINDER INSTALLER
 echo -e "$OKBLUE[*]$RESET Installing SubFinder...$RESET"
 go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest


### PR DESCRIPTION
apt-get install golang installs an outdated version of go, and the go get commands were resulting in an error.

I have updated the go get commands to go install <pkg>@latest and removed any apt-get install golang commands.  Having the latest version of go installed is a prerequisite but I can add the installation steps for ubuntu into the script in a couple of days. 